### PR TITLE
Change meta-openembedded version to use v4l-utils 1.18.0 like meta-st-openstlinux

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -19,7 +19,7 @@
   <project  remote="github"
             upstream="dunfell"
             name="openembedded/meta-openembedded"
-            revision="8a72d29e0876830ffd96b85d7d0308302eb07a5d"
+            revision="574c1aa730c2e664eb0a6aa31e6edb286d8eb0bc"
             path="sources/meta-openembedded" />
 
   <project  remote="github"


### PR DESCRIPTION
meta-st-openstlinux uses v4l-utils 1.18.0 ([bbappend](https://github.com/STMicroelectronics/meta-st-openstlinux/blob/5465ed3781355776cb46d2cc45884b1ccc1011cd/recipes-multimedia/v4l2apps/v4l-utils_1.18.0.bbappend))

While the version of meta-oe pointed by the commit hash in your default.xml file uses [v4l-utils version 1.18.1](https://github.com/openembedded/meta-openembedded/blob/8a72d29e0876830ffd96b85d7d0308302eb07a5d/meta-oe/recipes-multimedia/v4l2apps/v4l-utils_1.18.1.bb).
[This commit](https://github.com/openembedded/meta-openembedded/commit/097391c7b09ebbec7512ec9e7c3a7d6bfaea1775) made the upgrade.
So I refer to [the commit just before](https://github.com/openembedded/meta-openembedded/commit/574c1aa730c2e664eb0a6aa31e6edb286d8eb0bc).